### PR TITLE
Fix AttachCustomWheelEventHandler error in frontend.

### DIFF
--- a/XtermBlazor/XtermHandler.cs
+++ b/XtermBlazor/XtermHandler.cs
@@ -188,6 +188,18 @@ namespace XtermBlazor
             return GetTerminal(id)?.CustomKeyEventHandler.Invoke(@event) ?? true;
         }
 
+        /// <summary>
+        /// An event handler before wheel are processed
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="event"></param>
+        /// <returns></returns>
+        [JSInvokable]
+        public static bool AttachCustomWheelEventHandler(string id, WheelEventArgs @event)
+        {
+            return GetTerminal(id)?.CustomWheelEventHandler.Invoke(@event) ?? true;
+        }
+
         private static Xterm? GetTerminal(string id)
         {
             return _terminals.ContainsKey(id) ? _terminals[id] : null;


### PR DESCRIPTION
blazor.server.js:1 Uncaught (in promise) Error: System.ArgumentException: The assembly 'XtermBlazor' does not contain a public invokable method with [JSInvokableAttribute("AttachCustomWheelEventHandler")].
   at Microsoft.JSInterop.Infrastructure.DotNetDispatcher.GetCachedMethodInfo(:5001/AssemblyKey assemblyKey, String methodIdentifier)
   at Microsoft.JSInterop.Infrastructure.DotNetDispatcher.InvokeSynchronously(:5001/JSRuntime jsRuntime, DotNetInvocationInfo& callInfo, IDotNetObjectReference objectReference, String argsJson)
   at Microsoft.JSInterop.Infrastructure.DotNetDispatcher.BeginInvokeDotNet(:5001/JSRuntime jsRuntime, DotNetInvocationInfo invocationInfo, String argsJson)
    at y.endInvokeDotNetFromJS (blazor.server.js:1:3502)
    at Xt._invokeClientMethod (blazor.server.js:1:61001)
    at Xt._processIncomingData (blazor.server.js:1:58476)
    at Xt.connection.onreceive (blazor.server.js:1:52117)
    at s.onmessage (blazor.server.js:1:80262)