### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-publish-nuget.yml
+++ b/.github/workflows/dotnet-publish-nuget.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BattlefieldDuck/XtermBlazor/security/code-scanning/7](https://github.com/BattlefieldDuck/XtermBlazor/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required. Based on the workflow's operations, it needs `contents: read` to access the repository contents and `packages: write` to publish the NuGet package. These permissions will be explicitly set to ensure the workflow operates securely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
