### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-publish-gpr.yml
+++ b/.github/workflows/dotnet-publish-gpr.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BattlefieldDuck/XtermBlazor/security/code-scanning/6](https://github.com/BattlefieldDuck/XtermBlazor/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required. Based on the workflow's steps, the `contents: read` permission is sufficient for most operations, but the `packages: write` permission is required to publish the package to GPR. This ensures that the workflow has only the permissions it needs and adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
